### PR TITLE
Feature/fetch agent after docker runing

### DIFF
--- a/Dockerfile.fetch-agent-onrun
+++ b/Dockerfile.fetch-agent-onrun
@@ -1,0 +1,57 @@
+FROM centos:7
+
+ARG VSTS_BASE_DIR="/azp"
+ARG VSTS_LINUX_USER="vsts"
+ARG TINI_VERSION="v0.18.0"
+
+ENV VSTS_BASE_DIR="${VSTS_BASE_DIR}"
+ENV VSTS_LINUX_USER="${VSTS_LINUX_USER}"
+ENV VSTS_VERSION="${VSTS_VERSION}"
+
+# ENV agent.disableupdate=true
+
+# General Update
+RUN \
+yum -y --obsoletes update && \
+yum -y install sudo bsdtar
+
+## Install dependencies including: Git 2.x
+
+RUN \
+yum install -y openssl-libs libcurl krb5-libs zlib libicu wget && \
+rpm -ivh http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+yum install -y jq && \
+wget -P /etc/yum.repos.d/ https://packages.efficios.com/repo.files/EfficiOS-RHEL7-x86-64.repo && \
+rpmkeys --import https://packages.efficios.com/rhel/repo.key && \
+yum updateinfo && \
+yum install -y lttng-ust && \
+yum install -y centos-release-scl libunwind.x86_64 including && \
+yum install -y rh-git29.x86_64 && \
+echo 'source scl_source enable rh-git29' > /etc/profile.d/git29.sh && \
+chmod 644 /etc/profile.d/git29.sh && \
+source scl_source enable rh-git29 && \
+git --version
+
+# Better to run this under an init: Add Tini
+RUN \
+curl -sSfL -o /opt/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static && \
+chmod 755 /opt/tini
+
+## Install VSTS (prepare)
+RUN \
+useradd -u 1001 -c VSTS -m -U "${VSTS_LINUX_USER}" && \
+mkdir -p "${VSTS_BASE_DIR}/bin" && \
+mkdir -p "${VSTS_BASE_DIR}/tmp/_work" && \
+chown -R "${VSTS_LINUX_USER}" "${VSTS_BASE_DIR}"
+
+## Install VSTS download script
+COPY start.sh "${VSTS_BASE_DIR}/"
+
+ENTRYPOINT ["/opt/tini", "-g", "--"]
+
+WORKDIR "${VSTS_BASE_DIR}"
+
+VOLUME "${VSTS_BASE_DIR}/tmp"
+
+CMD [ "bash", "start.sh" ]
+

--- a/Dockerfile.fetch-agent-onrun
+++ b/Dockerfile.fetch-agent-onrun
@@ -53,5 +53,5 @@ WORKDIR "${VSTS_BASE_DIR}"
 
 VOLUME "${VSTS_BASE_DIR}/tmp"
 
-CMD [ "bash", "start.sh" ]
+CMD [ "bash", "--login", "start.sh" ]
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+set -e
+
+if [ -z "$AZP_URL" ]; then
+  echo 1>&2 "error: missing AZP_URL environment variable"
+  exit 1
+fi
+
+if [ -z "$AZP_TOKEN_FILE" ]; then
+  if [ -z "$AZP_TOKEN" ]; then
+    echo 1>&2 "error: missing AZP_TOKEN environment variable"
+    exit 1
+  fi
+
+  AZP_TOKEN_FILE=/azp/.token
+  echo -n $AZP_TOKEN > "$AZP_TOKEN_FILE"
+fi
+
+unset AZP_TOKEN
+
+if [ -n "$AZP_WORK" ]; then
+  mkdir -p "$AZP_WORK"
+fi
+
+rm -rf /azp/agent
+mkdir /azp/agent
+cd /azp/agent
+
+export AGENT_ALLOW_RUNASROOT="1"
+
+cleanup() {
+  if [ -e config.sh ]; then
+    print_header "Cleanup. Removing Azure Pipelines agent..."
+
+    ./config.sh remove --unattended \
+      --auth PAT \
+      --token $(cat "$AZP_TOKEN_FILE")
+  fi
+}
+
+print_header() {
+  lightcyan='\033[1;36m'
+  nocolor='\033[0m'
+  echo -e "${lightcyan}$1${nocolor}"
+}
+
+# Let the agent ignore the token env variables
+export VSO_AGENT_IGNORE=AZP_TOKEN,AZP_TOKEN_FILE
+
+print_header "1. Determining matching Azure Pipelines agent..."
+
+AZP_AGENT_RESPONSE=$(curl -LsS \
+  -u user:$(cat "$AZP_TOKEN_FILE") \
+  -H 'Accept:application/json;api-version=3.0-preview' \
+  "$AZP_URL/_apis/distributedtask/packages/agent?platform=linux-x64")
+
+if echo "$AZP_AGENT_RESPONSE" | jq . >/dev/null 2>&1; then
+  AZP_AGENTPACKAGE_URL=$(echo "$AZP_AGENT_RESPONSE" \
+    | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
+fi
+
+if [ -z "$AZP_AGENTPACKAGE_URL" -o "$AZP_AGENTPACKAGE_URL" == "null" ]; then
+  echo 1>&2 "error: could not determine a matching Azure Pipelines agent - check that account '$AZP_URL' is correct and the token is valid for that account"
+  exit 1
+fi
+
+print_header "2. Downloading and installing Azure Pipelines agent..."
+
+curl -LsS $AZP_AGENTPACKAGE_URL | tar -xz & wait $!
+
+source ./env.sh
+
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+print_header "3. Configuring Azure Pipelines agent..."
+
+./config.sh --unattended \
+  --agent "${AZP_AGENT_NAME:-$(hostname)}" \
+  --url "$AZP_URL" \
+  --auth PAT \
+  --token $(cat "$AZP_TOKEN_FILE") \
+  --pool "${AZP_POOL:-Default}" \
+  --work "${AZP_WORK:-_work}" \
+  --replace \
+  --acceptTeeEula & wait $!
+
+print_header "4. Running Azure Pipelines agent..."
+
+# `exec` the node runtime so it's aware of TERM and INT signals
+# AgentService.js understands how to handle agent self-update and restart
+exec ./externals/node/bin/node ./bin/AgentService.js interactive


### PR DESCRIPTION
According to the azure agent pipeline document, I found that we could fetch the azure pipeline agent after docker running.
- https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/docker?view=azure-devops

In the Dockerfile.fetch-agent-onrun, I use the following environment variables for azure-pipeline-agent.
- AZP_TOKEN=THE_PAT_TOKEN
- AZP_POOL=THE_AGENT_POOL_NAME
- AZP_URL=https://dev.azure.com/THE_ORGANIZATION_NAME

They will replace the variables PAT_TOKEN, AGENT_POOL, and VSTS_URL.